### PR TITLE
Allowing different location and filename for the configuration file

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -6,7 +6,7 @@
 
 =head1 VERSION
 
- 0.8.2
+ 0.8.3
 
 =head1 USAGE
 
@@ -40,14 +40,17 @@
   --email_addr      Email address to send successful/error report to (defaults to email_auth_user)
   --outbound_server Server to send mail through
   --helo            Change the HELO that is sent to the outbound server, this setting defaults to the current hostname
+  --config_file    Specify the location of the configuration file (defaults to ~/.cpaneldyndns)
 
-=head2 Using a Config File (.cpaneldyndns)
+=head2 Using a Config File (~/.cpaneldyndns)
 
-    Instead of passing options on the command line, a configuration file in your home directory can be used.
-    Any options specified on the command line will override the configuration file options.
-    This file has to be called .cpaneldyndns, and the file takes the format of 'option=value', eg:
+    Instead of passing options on the command line, a configuration file can be used.
+    Any options specified on the command line will ben override the configuration file options.
+    The file takes the format of 'option=value', eg:
     host=home
     domain=mydomain.com
+    
+    The default location of the configuration file is in the home folder of the current user and the default filename is '.cpaneldyndns'
 
 =head1 EXIT STATUS
 


### PR DESCRIPTION
By just changing the order of reading command arguments and configuration file, it is possible to specify a configuration file in a different location than the default one. This can be very useful when you need to e.g. setup a systemd timer and you might want to place the script and configuration file in different locations.

Just a suggestion, although there might be a cleaner way to do it
